### PR TITLE
Trailing periods are displayed correctly (see issue #7)

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -312,6 +312,10 @@ function extractDomain(url) {
  * set given url as new global torpedo url
  */
 function setNewUrl(uri) {
+  if (uri.hostname.slice(-1) === ".")
+    uri = new URL(
+      `${uri.href.replace(uri.hostname, uri.hostname.slice(0, -1))}`
+    );
   torpedo.uri = uri;
   torpedo.url = uri.href;
   torpedo.domain = extractDomain(uri.hostname);


### PR DESCRIPTION
Closing issue #7 by removing trailing periods in the domain of an url.